### PR TITLE
modify/remove MCVS fields, fix revision strings

### DIFF
--- a/DRIVERS/MDIS_LL/M099/DRIVER/COM/driver.mak
+++ b/DRIVERS/MDIS_LL/M099/DRIVER/COM/driver.mak
@@ -1,12 +1,9 @@
 #***************************  M a k e f i l e  *******************************
 #
-#        $Author: cs $
-#          $Date: 2004/05/05 14:11:43 $
-#      $Revision: 1.3 $
-#        $Header: /dd2/CVSR/COM/DRIVERS/MDIS_LL/M099/DRIVER/COM/driver.mak,v 1.3 2004/05/05 14:11:43 cs Exp $
+#         Author: cs
 #
 #    Description: makefile descriptor file for common
-#                 modules MDIS 4.0   e.g. low level driver
+#                 modules e.g. low level driver
 #
 #-----------------------------------------------------------------------------
 #   Copyright (c) 1997-2019, MEN Mikro Elektronik GmbH
@@ -26,7 +23,12 @@
 
 MAK_NAME=m99
 
+# the next line is updated during the MDIS installation
+STAMPED_REVISION="13M099-06_02_15-0-g31531d1-dirty_2019-02-21"
+
+DEF_REVISION=MAK_REVISION=$(STAMPED_REVISION)
 MAK_SWITCH=$(SW_PREFIX)MAC_MEM_MAPPED \
+           $(SW_PREFIX)$(DEF_REVISION)
 
 MAK_LIBS=$(LIB_PREFIX)$(MEN_LIB_DIR)/desc$(LIB_SUFFIX)     \
          $(LIB_PREFIX)$(MEN_LIB_DIR)/mbuf$(LIB_SUFFIX)     \

--- a/DRIVERS/MDIS_LL/M099/DRIVER/COM/driver_sw.mak
+++ b/DRIVERS/MDIS_LL/M099/DRIVER/COM/driver_sw.mak
@@ -1,12 +1,9 @@
 #***************************  M a k e f i l e  *******************************
 #
-#        $Author: cs $
-#          $Date: 2004/05/05 14:11:45 $
-#      $Revision: 1.4 $
-#        $Header: /dd2/CVSR/COM/DRIVERS/MDIS_LL/M099/DRIVER/COM/driver_sw.mak,v 1.4 2004/05/05 14:11:45 cs Exp $
+#         Author: cs
 #
 #    Description: makefile descriptor file for common
-#                 modules MDIS 4.0   e.g. low level driver
+#                 modules e.g. low level driver
 #
 #-----------------------------------------------------------------------------
 #   Copyright (c) 1997-2019, MEN Mikro Elektronik GmbH
@@ -48,9 +45,13 @@ MAK_INCL=$(MEN_INC_DIR)/m99_drv.h     \
          $(MEN_INC_DIR)/dbg.h    \
 
 
+# the next line is updated during the MDIS installation
+STAMPED_REVISION="13M099-06_02_15-0-g31531d1-dirty_2019-02-21"
+
+DEF_REVISION=MAK_REVISION=$(STAMPED_REVISION)
 MAK_SWITCH=$(SW_PREFIX)MAC_MEM_MAPPED \
-		   $(SW_PREFIX)MAC_BYTESWAP \
 		   $(SW_PREFIX)ID_SW \
+		   $(SW_PREFIX)$(DEF_REVISION)
 
 MAK_INP1=m99_drv$(INP_SUFFIX)
 MAK_INP2=

--- a/DRIVERS/MDIS_LL/M099/DRIVER/COM/m99_drv.c
+++ b/DRIVERS/MDIS_LL/M099/DRIVER/COM/m99_drv.c
@@ -1,11 +1,9 @@
 /*********************  P r o g r a m  -  M o d u l e ***********************
  *
  *         Name: m99_drv.c
- *      Project: M99 module driver (MDIS V4.x)
+ *      Project: M99 module driver
  *
  *       Author: uf
- *        $Date: 2010/08/20 14:10:23 $
- *    $Revision: 1.19 $
  *
  *  Description: Low level driver for M99 modules
  *
@@ -32,8 +30,6 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-static const char RCSid[]="M99 - m99 low level driver $Id: m99_drv.c,v 1.19 2010/08/20 14:10:23 CKauntz Exp $";
-
 /* pass debug definitions to dbg.h */
 #define DBG_MYLEVEL		m99Hdl->dbgLevel
 
@@ -55,6 +51,7 @@ static const char RCSid[]="M99 - m99 low level driver $Id: m99_drv.c,v 1.19 2010
 /*-----------------------------------------+
 |  DEFINES & CONST                         |
 +------------------------------------------*/
+static const char IdentString[]=MENT_XSTR(MAK_REVISION);
 #define MOD_ID_MAGIC_WORD   0x5346        /* eeprom identification (magic) */
 #define M99_MOD_ID          99
 #define M99_DONT_ID_CHECK 0
@@ -189,7 +186,7 @@ static int32 M99_Info(        int32     infoType, ... );
  ****************************************************************************/
 static char* M99_Ident( void )
 {
-    return( (char*) RCSid );
+    return( (char*) IdentString );
 }/*M99_Ident*/
 
 

--- a/DRIVERS/MDIS_LL/M099/TOOLS/M99_LATENCY/COM/m99_latency.c
+++ b/DRIVERS/MDIS_LL/M099/TOOLS/M99_LATENCY/COM/m99_latency.c
@@ -3,8 +3,6 @@
  *        \file  m99_latency.c
  *
  *      \author  klaus.popp@men.de
- *        $Date: 2010/08/20 14:10:25 $
- *    $Revision: 1.12 $
  * 
  *  	 \brief  Measures interrupt and signal latency 
  *
@@ -28,8 +26,6 @@
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
-
-static char *RCSid="$Id: m99_latency.c,v 1.12 2010/08/20 14:10:25 CKauntz Exp $";
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -63,6 +59,7 @@ typedef struct {
 
 static STATS G_irqStats, G_sigStats;
 static MDIS_PATH G_path;
+static const char IdentString[]=MENT_XSTR(MAK_REVISION);
 
 /**********************************************************************/
 /** print usage
@@ -77,7 +74,7 @@ static void usage(void)
 	printf("    -i=<interval>  interval      [1]=1s\n");
 	printf("    device     devicename (M99)        [none]\n");
 	printf("\n");
-	printf("%s\n", RCSid );
+	printf("%s\n", IdentString );
 	printf("(c) 2003..2010 by MEN mikro elektronik GmbH\n\n");
 }
 

--- a/DRIVERS/MDIS_LL/M099/TOOLS/M99_LATENCY/COM/program.mak
+++ b/DRIVERS/MDIS_LL/M099/TOOLS/M99_LATENCY/COM/program.mak
@@ -1,5 +1,11 @@
 MAK_NAME=m99_latency
 
+# the next line is updated during the MDIS installation
+STAMPED_REVISION="13M099-06_02_15-0-g31531d1-dirty_2019-02-21"
+
+DEF_REVISION=MAK_REVISION=$(STAMPED_REVISION)
+MAK_SWITCH=$(SW_PREFIX)$(DEF_REVISION)
+
 MAK_LIBS=$(LIB_PREFIX)$(MEN_LIB_DIR)/usr_oss$(LIB_SUFFIX)     \
          $(LIB_PREFIX)$(MEN_LIB_DIR)/usr_utl$(LIB_SUFFIX)     \
          $(LIB_PREFIX)$(MEN_LIB_DIR)/mdis_api$(LIB_SUFFIX)    \

--- a/PACKAGE_DESC/13m09906.xml
+++ b/PACKAGE_DESC/13m09906.xml
@@ -3,8 +3,8 @@
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="packagedesc.xsd">
 	<name>13m09906</name>
 	<description>MDIS5 driver package for MEN M99 M-Module</description>
-	<date>2010-08-20</date>
-	<revision>2.13</revision>
+	<date>2019-02-21</date>
+	<revision>13M099-06_02_15-0-g31531d1-dirty</revision>
 	<modellist>
 		<model>
 			<hwname>M99</hwname>


### PR DESCRIPTION
Belongs to https://github.com/MEN-Mikro-Elektronik/13MD05-90/issues/94
The dp_fixrevs branch of the 13M099-06 repo is an example how to modify/remove MCVS fields and provide proper revision strings.
This modifications are necessary in all MDIS submodule repos. 
The details are described in issue #94.